### PR TITLE
Show full post content in the index page when no excerpt is provided

### DIFF
--- a/layout/mixins/post.pug
+++ b/layout/mixins/post.pug
@@ -15,9 +15,13 @@ mixin posts()
                         a.post-title-link(href= url_for(item.path))
                             != item.title
                     +postInfo(item)
-                    .post-content
-                        != item.excerpt
-                    a.read-more(href= url_for(item.path))!= __('more')
+                    if item.excerpt
+                        .post-content
+                            != item.excerpt
+                        a.read-more(href= url_for(item.path))!= __('more')
+                    else
+                        .post-content
+                            != item.content
         - })
 
 //- Archive Page


### PR DESCRIPTION
Currently, when no excerpt is provided, the index page will just show a lonely '...more' link.
This change makes it so that the full post's content will be displayed in such cases, without the '...more' link (the post's title still functions as a link to the post itself).

Before - 
![image](https://user-images.githubusercontent.com/1256003/70853673-f8a03300-1e65-11ea-9565-54b8c8961d34.png)



After - 
![image](https://user-images.githubusercontent.com/1256003/70853686-18cff200-1e66-11ea-9f7c-25e7d6f32e60.png)
